### PR TITLE
Fix admin form media rendering for Select2 widgets after Django 5.2 upgrade

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -6,10 +6,11 @@ from django.contrib.admin.utils import model_ngettext
 from django.db.models import Prefetch
 from django.db.utils import IntegrityError
 from django.forms import CheckboxSelectMultiple, ModelForm
+from django.forms.widgets import Script
 from django.http import HttpResponseRedirect
 from django.templatetags.static import static
 from django.urls import re_path, reverse
-from django.utils.html import format_html, html_safe
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django_object_actions import DjangoObjectActions
 from parler.admin import TranslatableAdmin
@@ -54,11 +55,8 @@ class CurriculumCourseMembershipForm(ModelForm):
         }
 
 
-@html_safe
-class SortableSelectJSPath:
-    def __str__(self):
-        abs_path = static('js/sortable_select.js')
-        return f'<script src="{abs_path}" defer></script>'
+def sortable_select_script():
+    return Script(static('js/sortable_select.js'), defer=True)
 
 
 class ProgramEligibilityFilter(admin.SimpleListFilter):
@@ -237,7 +235,7 @@ class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         js = (
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
             'bower_components/jquery/dist/jquery.min.js',
-            SortableSelectJSPath()
+            sortable_select_script(),
         )
 
 
@@ -588,7 +586,7 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         js = (
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
             'bower_components/jquery/dist/jquery.min.js',
-            SortableSelectJSPath()
+            sortable_select_script(),
         )
 
 

--- a/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_run.html
+++ b/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_run.html
@@ -6,16 +6,17 @@
 {% endblock %}
 
 {% block extrastyle %}
-<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet">
+  {{ block.super }}
+  {{ form.media.css }}
 {% endblock %}
 
 {% block extrahead %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        $('.select2').select2();
-    });
-</script>
+  {{ block.super }}
+{% endblock %}
+
+{% block extrabody %}
+  {{ block.super }}
+  {{ form.media.js }}
 {% endblock %}
 
 {% block content %}

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from django.test import LiveServerTestCase, TestCase
 from django.test.utils import override_settings
+from django.templatetags.static import static
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 from selenium import webdriver
@@ -85,6 +86,10 @@ class AdminTests(SiteMixin, TestCase):
         """ Verify in admin panel program detail form load successfully. """
         response = self.client.get(reverse('admin:course_metadata_program_change', args=(self.program.id,)))
         assert response.status_code == 200
+        response_content = BeautifulSoup(response.content, "html.parser")
+        script_tag = response_content.find("script", {"src": static("js/sortable_select.js")})
+        assert script_tag is not None
+        assert script_tag.has_attr("defer")
 
     def test_custom_course_selection_page(self):
         """ Verify that course selection page loads successfully. """


### PR DESCRIPTION
### Motivation
- A Django 5.2 upgrade changed form media to use `Script` asset objects and added an `extrabody` admin block, which caused Select2-based multi-select widgets to lose their enhanced UI and render as plain `<select multiple>` elements. 
- A temporary hotfix injected Select2 via CDN into `course_run.html`, which only masked the root cause and introduced runtime CDN dependency and brittleness. 
- The correct fix is to align course-discovery with Django 5.2 media handling (do not treat media entries as raw strings and render JS in the admin `extrabody`).

### Description
- Replaced a manual script-tag string for the sortable-select helper with a proper Django `Script` asset by adding `from django.forms.widgets import Script` and exposing `sortable_select_script()` that returns `Script(static('js/sortable_select.js'), defer=True)` in `course_discovery/apps/course_metadata/admin.py`.
- Updated admin `Media` definitions to include `sortable_select_script()` so Django will render the script asset correctly for registered ModelAdmin classes in `admin.py`.
- Removed the Select2 CDN injection from `course_discovery/apps/course_metadata/templates/admin/course_metadata/course_run.html` and restored correct media rendering by adding `{{ form.media.css }}` to the `extrastyle` block and `{{ form.media.js }}` to the `extrabody` block while preserving `{{ block.super }}`.
- Added a regression assertion in `course_discovery/apps/course_metadata/tests/test_admin.py` to verify the deferred `js/sortable_select.js` script tag is present on the program admin change page.

### Testing
- Added a unit assertion (`AdminTests.test_program_detail_form`) that parses the program change page and asserts a `<script src="...js/sortable_select.js">` tag exists and has the `defer` attribute, but the full test suite was not executed as part of this rollout.
- No automated CI or test runs were performed here; please run the repository test suite and CI to validate widget rendering under Django 5.2 and browser-based behavior for Select2 UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961036db820832e976404fdfcc011f6)